### PR TITLE
Renames SetContext 'attribute' methods

### DIFF
--- a/Sources/StatementSQLite/SetContext.swift
+++ b/Sources/StatementSQLite/SetContext.swift
@@ -19,11 +19,11 @@ public extension Segment where Context == SQLiteStatement.SetContext {
         ])
     }
     
-    static func attribute<E: Entity>(_ type: E.Type, attribute: Attribute, op: ComparisonOperator, value: DataTypeConvertible) -> Segment {
-        self.attribute(attribute, entity: E.init(), op: op, value: value)
+    static func column<E: Entity>(_ type: E.Type, attribute: Attribute, op: ComparisonOperator, value: DataTypeConvertible) -> Segment {
+        self.column(attribute, entity: E.init(), op: op, value: value)
     }
     
-    static func attribute(_ attribute: Attribute, entity: Entity? = nil, op: ComparisonOperator, value: DataTypeConvertible) -> Segment {
+    static func column(_ attribute: Attribute, entity: Entity? = nil, op: ComparisonOperator, value: DataTypeConvertible) -> Segment {
         .comparison(op: op, segments: [
             Segment<SQLiteStatement.SetContext>.attribute(attribute, entity: entity),
             .value(value)

--- a/Tests/StatementTests/SQLite/SQLiteStatement_UpdateContextTests.swift
+++ b/Tests/StatementTests/SQLite/SQLiteStatement_UpdateContextTests.swift
@@ -51,8 +51,8 @@ final class SQLiteStatement_UpdateContextTests: XCTestCase {
         var statement: SQLiteStatement = .init(
             .UPDATE_TABLE(CatalogTranslation.self),
             .SET(
-                .attribute(value, op: .equal, value: "Corrected Translation"),
-                .attribute(region, op: .equal, value: nullRegion)
+                .column(value, op: .equal, value: "Corrected Translation"),
+                .column(region, op: .equal, value: nullRegion)
             ),
             .WHERE(
                 .column(id, op: .equal, value: 123)
@@ -68,8 +68,8 @@ final class SQLiteStatement_UpdateContextTests: XCTestCase {
         statement = .init(
             .UPDATE_TABLE(CatalogTranslation.self),
             .SET(
-                .attribute(value, op: .equal, value: "Corrected Translation"),
-                .attribute(region, op: .equal, value: nullRegion)
+                .column(value, op: .equal, value: "Corrected Translation"),
+                .column(region, op: .equal, value: nullRegion)
             ),
             .WHERE(
                 .column(value, op: .like, value: "%bob%")


### PR DESCRIPTION
To keep consistent with the rest of the API, the `attribute` methods used in the `SetContext` should be renamed `column`.