### PR TITLE
Wrapped Data

### DIFF
--- a/Sources/StatementSQLite/DataTypeConvertible+SQLite.swift
+++ b/Sources/StatementSQLite/DataTypeConvertible+SQLite.swift
@@ -13,8 +13,7 @@ public extension DataTypeConvertible {
         case let value as Bool:
             return value ? "1" : "0"
         case let value as Data:
-            let hex = value.map { String(format: "%02hhx", $0) }.joined()
-            return "X(" + hex + ")"
+            return .singleQuote + (String(data: value, encoding: .utf8) ?? "") + .singleQuote
         case let value as Date:
             return "\(value.timeIntervalSince1970)"
         case let value as Double:

--- a/Sources/StatementSQLite/DataTypeConvertible+SQLite.swift
+++ b/Sources/StatementSQLite/DataTypeConvertible+SQLite.swift
@@ -13,7 +13,8 @@ public extension DataTypeConvertible {
         case let value as Bool:
             return value ? "1" : "0"
         case let value as Data:
-            return String(data: value, encoding: .utf8) ?? ""
+            let hex = value.map { String(format: "%02hhx", $0) }.joined()
+            return "X(" + hex + ")"
         case let value as Date:
             return "\(value.timeIntervalSince1970)"
         case let value as Double:

--- a/Tests/StatementTests/SQLite/SQLiteDataTypeConvertibleTests.swift
+++ b/Tests/StatementTests/SQLite/SQLiteDataTypeConvertibleTests.swift
@@ -24,11 +24,11 @@ final class SQLiteDataTypeConvertibleTests: XCTestCase {
         
         let data = try XCTUnwrap("A Bag Of Bytes".data(using: .utf8))
         let nonOptional: Data = data
-        XCTAssertEqual(nonOptional.sqliteArgument, "A Bag Of Bytes")
+        XCTAssertEqual(nonOptional.sqliteArgument, "X(4120426167204f66204279746573)")
         var optional: Data? = nil
         XCTAssertEqual(optional.sqliteArgument, "NULL")
         optional = try JSONEncoder().encode(User(name: "Merlin"))
-        XCTAssertEqual(optional.sqliteArgument, "{\"name\":\"Merlin\"}")
+        XCTAssertEqual(optional.sqliteArgument, "X(7b226e616d65223a224d65726c696e227d)")
     }
     
     func testDateSqliteArgument() throws {

--- a/Tests/StatementTests/SQLite/SQLiteDataTypeConvertibleTests.swift
+++ b/Tests/StatementTests/SQLite/SQLiteDataTypeConvertibleTests.swift
@@ -24,11 +24,11 @@ final class SQLiteDataTypeConvertibleTests: XCTestCase {
         
         let data = try XCTUnwrap("A Bag Of Bytes".data(using: .utf8))
         let nonOptional: Data = data
-        XCTAssertEqual(nonOptional.sqliteArgument, "X(4120426167204f66204279746573)")
+        XCTAssertEqual(nonOptional.sqliteArgument, "'A Bag Of Bytes'")
         var optional: Data? = nil
         XCTAssertEqual(optional.sqliteArgument, "NULL")
         optional = try JSONEncoder().encode(User(name: "Merlin"))
-        XCTAssertEqual(optional.sqliteArgument, "X(7b226e616d65223a224d65726c696e227d)")
+        XCTAssertEqual(optional.sqliteArgument, "'{\"name\":\"Merlin\"}'")
     }
     
     func testDateSqliteArgument() throws {


### PR DESCRIPTION
Since the framework is treating `Data` as an encoded `String` when producing the `sqliteArgument`... the resulting string should have single quotes.